### PR TITLE
WN-1731 | Disable the microphone button when call status is ringing

### DIFF
--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
@@ -59,7 +59,7 @@ internal class ControlBarViewModel(private val dispatch: (Action) -> Unit) {
         cameraStateFlow.value = CameraModel(permissionState.cameraPermissionState, cameraState)
         audioOperationalStatusStateFlow.value = audioState.operation
         audioDeviceSelectionStatusStateFlow.value = audioState.device
-        shouldEnableMicButtonStateFlow.value = shouldEnableMicButton(audioState)
+        shouldEnableMicButtonStateFlow.value = shouldEnableMicButton(audioState, callingStatus)
         onHoldCallStatusStateFlow.value = callingStatus == CallingStatus.LOCAL_HOLD
     }
 
@@ -103,8 +103,8 @@ internal class ControlBarViewModel(private val dispatch: (Action) -> Unit) {
         dispatchAction(action = LocalParticipantAction.CameraOffTriggered())
     }
 
-    private fun shouldEnableMicButton(audioState: AudioState): Boolean {
-        return (audioState.operation != AudioOperationalStatus.PENDING)
+    private fun shouldEnableMicButton(audioState: AudioState, callingStatus: CallingStatus): Boolean {
+        return (audioState.operation != AudioOperationalStatus.PENDING && callingStatus != CallingStatus.RINGING)
     }
 
     private fun dispatchAction(action: Action) {

--- a/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
+++ b/azure-communication-ui/calling/src/main/java/com/azure/android/communication/ui/calling/presentation/fragment/calling/controlbar/ControlBarViewModel.kt
@@ -42,7 +42,7 @@ internal class ControlBarViewModel(private val dispatch: (Action) -> Unit) {
         audioOperationalStatusStateFlow = MutableStateFlow(audioState.operation)
         audioDeviceSelectionStatusStateFlow = MutableStateFlow(audioState.device)
         shouldEnableMicButtonStateFlow =
-            MutableStateFlow(shouldEnableMicButton(audioState))
+            MutableStateFlow(shouldEnableMicButton(audioState, callState.callingStatus))
         onHoldCallStatusStateFlow = MutableStateFlow(false)
         requestCallEnd = requestCallEndCallback
         openAudioDeviceSelectionMenu = openAudioDeviceSelectionMenuCallback


### PR DESCRIPTION
The microphone button should be disabled when the call's status is "ringing". 